### PR TITLE
Move logging setup to module level

### DIFF
--- a/dsagent/main.py
+++ b/dsagent/main.py
@@ -1,5 +1,9 @@
 """Simple orchestration script for DSAgent."""
 
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
 from .agent_manager import AgentManager
 from .agents.listing_agent import ListingAgent
 from .agents.order_agent import OrderAgent


### PR DESCRIPTION
## Summary
- configure logging in `dsagent.main` when the module is imported
- keep `main()` free of redundant logging setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843751e8778832d937c15250057240b